### PR TITLE
fix: hot-reload conflict in dev mode, fix #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ import { defineConfig } from 'vite'
 import shopify from 'vite-plugin-shopify'
 import importMaps from 'vite-plugin-shopify-import-maps'
 
+// Recommended configuration
 export default defineConfig({
   build: {
     rollupOptions: {
@@ -65,7 +66,7 @@ export default defineConfig({
       },
     },
   },
-  plugins: [shopify(), importMaps()],
+  plugins: [shopify({ versionNumbers: true }), importMaps()],
 })
 ```
 

--- a/src/import-maps.ts
+++ b/src/import-maps.ts
@@ -12,19 +12,26 @@ import type { PluginOptions } from './types'
 export default function importMaps (options?: PluginOptions): Plugin {
   const defaultFilename = 'importmap.liquid'
   const filename = options?.snippetFile ?? defaultFilename
+  const outDir = path.resolve(options?.themeRoot ?? './', 'snippets')
+  const importMapFile = path.join(outDir, filename)
 
   let config: ResolvedConfig
 
   return {
     name: 'vite-plugin-shopify-import-maps:import-maps',
-    apply: 'build',
     enforce: 'post',
     configResolved (resolvedConfig) {
       config = resolvedConfig
     },
+    async buildStart () {
+      if (config.command === 'serve') {
+        await fs.writeFile(
+          importMapFile,
+          ''
+        )
+      }
+    },
     async writeBundle (_, bundle) {
-      const outDir = path.resolve(options?.themeRoot ?? './', 'snippets')
-      const importMapFile = path.join(outDir, filename)
       const importMap = new Map<string, string>()
 
       await Promise.allSettled(


### PR DESCRIPTION
This PR is related to #3 and fix issue with hot-reload conflict in dev mode.

In dev mode, the plugin clears/creates an empty importmap file. We don't need import-maps because vitejs resolves it on its own.