### PR TITLE
fix: url issue with base tag, fix #5

### DIFF
--- a/src/import-maps.ts
+++ b/src/import-maps.ts
@@ -41,6 +41,7 @@ export default function importMaps (options?: PluginOptions): Plugin {
           }
 
           importMap.set(`{{ '${fileName}' | asset_url | split: '?' | first }}`, `{{ '${fileName}' | asset_url }}`)
+          importMap.set(`${config.base}${fileName}`, `{{ '${fileName}' | asset_url }}`)
         })
       )
 

--- a/src/import-maps.ts
+++ b/src/import-maps.ts
@@ -40,7 +40,7 @@ export default function importMaps (options?: PluginOptions): Plugin {
             return
           }
 
-          importMap.set(`${config.base}${fileName}`, `{{ '${fileName}' | asset_url }}`)
+          importMap.set(`{{ '${fileName}' | asset_url | split: '?' | first }}`, `{{ '${fileName}' | asset_url }}`)
         })
       )
 
@@ -48,7 +48,7 @@ export default function importMaps (options?: PluginOptions): Plugin {
 
       await fs.writeFile(
         importMapFile,
-        `<base href="{{ 'base' | asset_url | split: 'base' | first }}">\n<script type="importmap">\n${json}\n</script>`,
+        `<script type="importmap">\n${json}\n</script>`,
         { encoding: 'utf8' }
       )
 


### PR DESCRIPTION
This PR is related to #5 and fix issue with hash URL caused by `<base>` tag.

## Shortly about problem

> When <base> element is present in the document, all URLs and URL-like specifiers in the import map are converted to absolute URLs using the href from `<base>`.

In fact, it's not just about import maps, but all elements in that document are affected by a base URL change.

## Solution

In this PR I remove the base tag and add the absolute path in the specifier key of the import map.

For example, we have this importmap file:

```liquid
<script>
{
  "imports": {
     "https://shop.myshopify.com/cdn/shop/t/36/assets/utils.js": "https://shop.myshopify.com/cdn/shop/t/36/assets/utils.js?v=137883148668430395111696585034",
     "./utils.js": "https://shop.myshopify.com/cdn/shop/t/36/assets/utils.js?v=137883148668430395111696585034"
  }
}
</script>
```

this will generate an import map with imports of

```
«[
  "https://shop.myshopify.com/cdn/shop/t/36/assets/utils.js" → https://shop.myshopify.com/cdn/shop/t/36/assets/utils.js?v=137883148668430395111696585034
  "https://shop.myshopify.com/utils.js" → https://shop.myshopify.com/cdn/shop/t/36/assets/utils.js?v=137883148668430395111696585034
]»
```

1. So, If we import a module inside our `theme.js` file this way `import { debounce } from './utils.js'`. The browser will try to get the module relative to the current file. That is, if it is `https://shop.myshopify.com/cdn/shop/t/36/assets/theme.js?v=137883148668430395111696585034` for theme.js, it will be `https://shop.myshopify.com/cdn/shop/t/36/assets/utils.js` for utils.js.

2. If we import the module inside a `<script>` tag, the browser will try to get the module relative to the import map's base URL, i.e. the base URL of the page for inline import maps. That is, if base URL is `https://shop.myshopify.com/` for the current import map, it will be `https://shop.myshopify.com/utils.js` for utils.js.

Thus we correctly remapping for both cases.

[Learn more](https://html.spec.whatwg.org/multipage/webappapis.html#the-resolution-algorithm) about module specifier resolution algorithm and import map processing model.
