### PR TITLE
feat: add bare modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "build": "tsup",
     "dev": "tsup --watch",
     "lint": "eslint --ext .ts .",
+    "prepublish": "tsup",
     "release": "bumpp && pnpm publish"
   },
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -66,8 +66,10 @@
   "devDependencies": {
     "@types/node": "^20.5.9",
     "bumpp": "^9.2.0",
+    "es-module-lexer": "^1.3.1",
     "eslint": "^8.48.0",
     "eslint-config-standard-with-typescript": "^39.0.0",
+    "magic-string": "^0.30.5",
     "tsup": "^7.2.0",
     "typescript": "^5.2.2",
     "vite": "^4.4.9"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,12 +11,18 @@ devDependencies:
   bumpp:
     specifier: ^9.2.0
     version: 9.2.0
+  es-module-lexer:
+    specifier: ^1.3.1
+    version: 1.3.1
   eslint:
     specifier: ^8.48.0
     version: 8.48.0
   eslint-config-standard-with-typescript:
     specifier: ^39.0.0
     version: 39.0.0(@typescript-eslint/eslint-plugin@6.6.0)(eslint-plugin-import@2.28.1)(eslint-plugin-n@16.0.2)(eslint-plugin-promise@6.1.1)(eslint@8.48.0)(typescript@5.2.2)
+  magic-string:
+    specifier: ^0.30.5
+    version: 0.30.5
   tsup:
     specifier: ^7.2.0
     version: 7.2.0(typescript@5.2.2)
@@ -897,6 +903,10 @@ packages:
       which-typed-array: 1.1.11
     dev: true
 
+  /es-module-lexer@1.3.1:
+    resolution: {integrity: sha512-JUFAyicQV9mXc3YRxPnDlrfBKpqt6hUYzz9/boprUJHs4e4KVr3XwOF70doO6gwXUor6EWZJAyWAfKki84t20Q==}
+    dev: true
+
   /es-set-tostringtag@2.0.1:
     resolution: {integrity: sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==}
     engines: {node: '>= 0.4'}
@@ -1741,6 +1751,13 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yallist: 4.0.0
+    dev: true
+
+  /magic-string@0.30.5:
+    resolution: {integrity: sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
   /merge-stream@2.0.0:

--- a/src/bare-modules.ts
+++ b/src/bare-modules.ts
@@ -90,10 +90,12 @@ export default function bareModules (options: PluginOptions): Plugin {
             }
           }
 
-          chunk.code = code.toString()
+          if (code.hasChanged() === true) {
+            chunk.code = code.toString()
 
-          if (options.sourcemap !== false) {
-            chunk.map = code.generateMap({ hires: true }) as Rollup.SourceMap
+            if (options.sourcemap !== false) {
+              chunk.map = code.generateMap({ hires: true }) as Rollup.SourceMap
+            }
           }
         }
       })

--- a/src/bare-modules.ts
+++ b/src/bare-modules.ts
@@ -1,0 +1,102 @@
+import type { Plugin, Rollup } from 'vite'
+import type { BareModules, PluginOptions } from './types'
+import path from 'node:path'
+import { parse } from 'es-module-lexer'
+import MagicString from 'magic-string'
+
+function buildSpecifierKey (name: string, group: string): string {
+  return group + '/' + name
+}
+
+/**
+ * Use bare specifier in import module statements defined in bareModules option groups.
+ */
+export default function bareModules (options: PluginOptions): Plugin {
+  const moduleSpecifierMap = new Map<string, string>()
+
+  return {
+    name: 'vite-plugin-shopify-import-maps:bare-modules',
+    api: {
+      get moduleSpecifierMap () {
+        return moduleSpecifierMap
+      }
+    },
+    renderChunk (_, chunk) {
+      const bareModules = options.bareModules as BareModules
+      const groups = bareModules.groups
+      const moduleId = chunk.facadeModuleId ?? chunk.moduleIds.at(-1)
+
+      let specifierKey: string | undefined
+
+      if (moduleId !== undefined) {
+        for (const group in groups) {
+          const value = groups[group]
+
+          if (typeof specifierKey === 'string') {
+            continue
+          }
+
+          if (Array.isArray(value)) {
+            const arrayTestPassed = value.some((element) => {
+              return (
+                (element instanceof RegExp && element.test(moduleId)) ||
+                  (typeof element === 'string' && moduleId.includes(element))
+              )
+            })
+
+            if (arrayTestPassed) {
+              specifierKey = buildSpecifierKey(chunk.name, group)
+              break
+            }
+          } else {
+            const regexpTestPassed = value instanceof RegExp && value.test(moduleId)
+            const stringTestPassed = typeof value === 'string' && moduleId.includes(value)
+
+            if (regexpTestPassed || stringTestPassed) {
+              specifierKey = buildSpecifierKey(chunk.name, group)
+              break
+            }
+          }
+        }
+      }
+
+      if (specifierKey === undefined) {
+        specifierKey = buildSpecifierKey(chunk.name, bareModules.defaultGroup)
+      }
+
+      moduleSpecifierMap.set(chunk.fileName, specifierKey)
+    },
+    generateBundle (options, bundle) {
+      Object.keys(bundle).forEach((fileName) => {
+        const chunk = bundle[fileName]
+
+        if (chunk.type === 'chunk') {
+          const code = new MagicString(chunk.code)
+          const [imports] = parse(chunk.code)
+
+          for (let { s, e, d, n } of imports) {
+            const name = path.parse(n ?? '').base
+            const specifier = moduleSpecifierMap.get(name)
+
+            if (specifier !== undefined) {
+              // Keep quotes for dynamic import.
+              // https://github.com/guybedford/es-module-lexer/issues/144
+              if (d > -1) {
+                s += 1
+                e -= 1
+              }
+
+              code.overwrite(s, e, specifier)
+            }
+          }
+
+          chunk.code = code.toString()
+
+          if (options.sourcemap !== false) {
+            chunk.map = code.generateMap({ hires: true }) as Rollup.SourceMap
+          }
+        }
+      })
+    }
+  }
+}

--- a/src/bare-modules.ts
+++ b/src/bare-modules.ts
@@ -4,10 +4,6 @@ import path from 'node:path'
 import { parse } from 'es-module-lexer'
 import MagicString from 'magic-string'
 
-function buildSpecifierKey (name: string, group: string): string {
-  return group + '/' + name
-}
-
 /**
  * Use bare specifier in import module statements defined in bareModules option groups.
  */
@@ -90,7 +86,7 @@ export default function bareModules (options: PluginOptions): Plugin {
             }
           }
 
-          if (code.hasChanged() === true) {
+          if (code.hasChanged()) {
             chunk.code = code.toString()
 
             if (options.sourcemap !== false) {
@@ -101,4 +97,8 @@ export default function bareModules (options: PluginOptions): Plugin {
       })
     }
   }
+}
+
+function buildSpecifierKey (name: string, group: string): string {
+  return group + '/' + name
 }

--- a/src/import-maps.ts
+++ b/src/import-maps.ts
@@ -1,7 +1,7 @@
 import type { Plugin, ResolvedConfig } from 'vite'
+import type { PluginOptions } from './types'
 import path from 'node:path'
 import fs from 'node:fs/promises'
-import type { PluginOptions } from './types'
 
 /**
  * Generates an import map file from a Vite bundle.

--- a/src/import-maps.ts
+++ b/src/import-maps.ts
@@ -5,17 +5,13 @@ import type { PluginOptions } from './types'
 
 /**
  * Generates an import map file from a Vite bundle.
- * @param {Object} options - The plugin options.
- * @property {string} options.snippetFile - Specifies the file name of the snippet that include import map.
- * @property {string} options.themeRoot - Root path to your Shopify theme directory.
  */
-export default function importMaps (options?: PluginOptions): Plugin {
-  const defaultFilename = 'importmap.liquid'
-  const filename = options?.snippetFile ?? defaultFilename
-  const outDir = path.resolve(options?.themeRoot ?? './', 'snippets')
-  const importMapFile = path.join(outDir, filename)
+export default function importMaps (options: PluginOptions): Plugin {
+  const outDir = path.resolve(options.themeRoot, 'snippets')
+  const importMapFile = path.join(outDir, options.snippetFile)
 
   let config: ResolvedConfig
+  let moduleSpecifierMap: Map<string, string>
 
   return {
     name: 'vite-plugin-shopify-import-maps:import-maps',
@@ -23,7 +19,14 @@ export default function importMaps (options?: PluginOptions): Plugin {
     configResolved (resolvedConfig) {
       config = resolvedConfig
     },
-    async buildStart () {
+    async buildStart ({ plugins }) {
+      if (options.bareModules !== false) {
+        const bareModulesPlugin = plugins.find((plugin) => plugin.name.includes('bare-modules'))
+        if (bareModulesPlugin !== undefined) {
+          moduleSpecifierMap = bareModulesPlugin.api.moduleSpecifierMap
+        }
+      }
+
       if (config.command === 'serve') {
         await fs.writeFile(
           importMapFile,
@@ -34,11 +37,24 @@ export default function importMaps (options?: PluginOptions): Plugin {
     async writeBundle (_, bundle) {
       const importMap = new Map<string, string>()
 
+      let chunks: string[][]
+
+      if (options.bareModules === false) {
+        chunks = Object.entries(bundle)
+          .filter(([_, chunk]) => chunk.type === 'chunk')
+          .map(([fileName]) => [fileName, config.base + fileName])
+      } else {
+        chunks = Array.from(moduleSpecifierMap.entries())
+      }
+
+      const sortedChunks = chunks.sort((a, b) => a[1].localeCompare(b[1]))
+
       await Promise.allSettled(
-        Object.keys(bundle).map(async (fileName) => {
-          if (fileName.endsWith('.js')) {
+        sortedChunks.map(async ([fileName, specifireKey]) => {
+          importMap.set(specifireKey, `{{ '${fileName}' | asset_url }}`)
+
+          if (options.bareModules === false) {
             importMap.set(`{{ '${fileName}' | asset_url | split: '?' | first }}`, `{{ '${fileName}' | asset_url }}`)
-            importMap.set(`${config.base}${fileName}`, `{{ '${fileName}' | asset_url }}`)
           }
         })
       )

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,37 @@
 import type { Plugin } from 'vite'
+import type { BareModules, PluginOptions } from './types'
 import preloadHelper from './preload-helper'
 import importMaps from './import-maps'
-import type { PluginOptions } from './types'
+import bareModules from './bare-modules'
 
 /**
  * The Vite plugin enhances Shopify themes by adding support for import maps,
  * which can be used to control the resolution of module specifiers.
  * @see {@link https://github.com/slavamak/vite-plugin-shopify-import-maps GitHub}
+ * @param {Object} options - The plugin options.
+ * @property {string} options.snippetFile - Specifies the file name of the snippet that include import map.
+ * @property {string} options.themeRoot - Root path to your Shopify theme directory.
+ * @property {boolean | BareModules} options.bareModules - Specifies whether to use bare modules or not, and define remapping groups for them.
  */
-const vitePluginShopifyImportMaps = (options?: PluginOptions): Plugin[] => {
+const vitePluginShopifyImportMaps = (userOptions?: PluginOptions): Plugin[] => {
+  const {
+    snippetFile = 'importmap.liquid',
+    themeRoot = './',
+    bareModules: bareModulesOption = false
+  } = userOptions ?? {}
+
   const plugins = [
     preloadHelper(),
-    importMaps(options)
+    importMaps({ snippetFile, themeRoot, bareModules: bareModulesOption })
   ]
+
+  if (bareModulesOption !== false) {
+    plugins.push(bareModules({
+      snippetFile,
+      themeRoot,
+      bareModules: { ...{ defaultGroup: 'main', groups: {} }, ...(bareModulesOption as BareModules) }
+    }))
+  }
 
   return plugins
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,10 +8,6 @@ import bareModules from './bare-modules'
  * The Vite plugin enhances Shopify themes by adding support for import maps,
  * which can be used to control the resolution of module specifiers.
  * @see {@link https://github.com/slavamak/vite-plugin-shopify-import-maps GitHub}
- * @param {Object} options - The plugin options.
- * @property {string} options.snippetFile - Specifies the file name of the snippet that include import map.
- * @property {string} options.themeRoot - Root path to your Shopify theme directory.
- * @property {boolean | BareModules} options.bareModules - Specifies whether to use bare modules or not, and define remapping groups for them.
  */
 const vitePluginShopifyImportMaps = (userOptions?: PluginOptions): Plugin[] => {
   const {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,10 @@
+export interface BareModules {
+  defaultGroup: string
+  groups: Record<string, string | RegExp | Array<string | RegExp>>
+}
+
 export interface PluginOptions {
   snippetFile: string
   themeRoot: string
+  bareModules: boolean | BareModules
 }


### PR DESCRIPTION
This PR is related to #7 and introduce new `bareModules` option.

I decided not to use `resolve.alias` option to configure this, as previously suggested. I just added additional `bareModules.groups` option to make this easier to understand and not misleading for the developer. 

Basically we get an `importmap.liquid` file that contains a import map with bare specifier keys. Also based on this, plugin transform all output chunks in which it replaces all module specifiers for static and dynamic imports.

Example:

```ts
export default defineConfig({
  plugins: [
    importMap({
      bareModules: {
        defaultGroup: 'main', // By default is 'main'
        groups: {
          helpers: /frontend\/lib/, // RegExp pattern
          vendors: 'node_modules', // String
          general: ['frontend/entrypoints', /vite/], // Array of string or RegExp pattern
        },
      },
    }),
  ],
})
```

```liquid
<script type="importmap">
{
  "imports": {
    "general/customers": "{{ 'customers.js' | asset_url }}",
    "general/modulepreload-polyfill": "{{ 'modulepreload-polyfill.js' | asset_url }}",
    "general/theme": "{{ 'theme.js' | asset_url }}",
    "helpers/customer-address": "{{ 'customer-address.js' | asset_url }}",
    "helpers/shopify_common": "{{ 'shopify_common.js' | asset_url }}",
    "helpers/utils": "{{ 'utils.js' | asset_url }}",
    "main/header-drawer": "{{ 'header-drawer.js' | asset_url }}",
    "main/localization-form": "{{ 'localization-form.js' | asset_url }}",
    "main/product-recommendations": "{{ 'product-recommendations.js' | asset_url }}",
    "vendors/lodash": "{{ 'lodash.js' | asset_url }}"
  }
}
</script>
```

```js
// ./assets/theme.js
import { __vitePreload } from "general/modulepreload-polyfill";
import customerAddress from "helpers/customer-address";
import { debounce } from "vendors/lodash";
```

We can also use the `manualChunks` option to create custom shared common chunks. For example, if we use `debounce` and `throttle` methods from the `lodash-es` library, then in some situations vite will generate separate chunks for each. So we can modify it like this:

```ts
manualChunks: {
  lodash: ['lodash-es'],
}
```

For more info check out rollup docs https://rollupjs.org/configuration-options/#output-manualchunks