### PR TITLE
feat: add modulePreload option

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ export default defineConfig({
   },
   plugins: [
     shopify({ versionNumbers: true }),
-    importMaps({ bareModules: true })
+    importMaps({ bareModules: true }),
   ],
 });
 ```
@@ -86,8 +86,8 @@ Specifies the file name of the snippet that include import map.
 
 ```ts
 export interface BareModules {
-  defaultGroup: string
-  groups: Record<string, string | RegExp | Array<string | RegExp>>
+  defaultGroup: string;
+  groups: Record<string, string | RegExp | Array<string | RegExp>>;
 }
 ```
 
@@ -100,16 +100,16 @@ export default defineConfig({
   plugins: [
     importMap({
       bareModules: {
-        defaultGroup: 'main', // By default is 'main'
+        defaultGroup: "main", // By default is 'main'
         groups: {
           helpers: /frontend\/lib/, // RegExp pattern
-          vendors: 'node_modules', // String
-          general: ['frontend/entrypoints', /vite/], // Array of string or RegExp pattern
+          vendors: "node_modules", // String
+          general: ["frontend/entrypoints", /vite/], // Array of string or RegExp pattern
         },
       },
     }),
   ],
-})
+});
 ```
 
 This generates the `importmap.liquid` file:
@@ -131,6 +131,18 @@ This generates the `importmap.liquid` file:
   }
 }
 </script>
+```
+
+### modulePreload
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+This option when set to `true`, generates `modulepreload` link tags below the import map script tag.
+
+```liquid
+<link rel="modulepreload" href="{{ 'customers.js' | asset_url }}">
+<link rel="modulepreload" href="{{ 'theme.js' | asset_url }}">
 ```
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -39,26 +39,26 @@ pnpm add -D vite-plugin-shopify-import-maps
 3. Add the `vite-plugin-shopify-import-maps` to your `vite.config.js` file:
 
 ```js
-import { defineConfig } from "vite";
-import shopify from "vite-plugin-shopify";
-import importMaps from "vite-plugin-shopify-import-maps";
+import { defineConfig } from 'vite'
+import shopify from 'vite-plugin-shopify'
+import importMaps from 'vite-plugin-shopify-import-maps'
 
 // Recommended configuration
 export default defineConfig({
   build: {
     rollupOptions: {
       output: {
-        entryFileNames: "[name].js",
-        chunkFileNames: "[name].js",
-        assetFileNames: "[name].[ext]",
-      },
-    },
+        entryFileNames: '[name].js',
+        chunkFileNames: '[name].js',
+        assetFileNames: '[name].[ext]'
+      }
+    }
   },
   plugins: [
     shopify({ versionNumbers: true }),
-    importMaps({ bareModules: true }),
-  ],
-});
+    importMaps({ bareModules: true })
+  ]
+})
 ```
 
 After executing the build command, the `importmap.liquid` file will be generated in the `snippets` folder in your theme root directory.
@@ -86,8 +86,8 @@ Specifies the file name of the snippet that include import map.
 
 ```ts
 export interface BareModules {
-  defaultGroup: string;
-  groups: Record<string, string | RegExp | Array<string | RegExp>>;
+  defaultGroup: string
+  groups: Record<string, string | RegExp | Array<string | RegExp>>
 }
 ```
 
@@ -100,16 +100,16 @@ export default defineConfig({
   plugins: [
     importMap({
       bareModules: {
-        defaultGroup: "main", // By default is 'main'
+        defaultGroup: 'main', // By default is 'main'
         groups: {
           helpers: /frontend\/lib/, // RegExp pattern
-          vendors: "node_modules", // String
-          general: ["frontend/entrypoints", /vite/], // Array of string or RegExp pattern
-        },
-      },
-    }),
-  ],
-});
+          vendors: 'node_modules', // String
+          general: ['frontend/entrypoints', /vite/] // Array of string or RegExp pattern
+        }
+      }
+    })
+  ]
+})
 ```
 
 This generates the `importmap.liquid` file:

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import bareModules from './bare-modules'
  * which can be used to control the resolution of module specifiers.
  * @see {@link https://github.com/slavamak/vite-plugin-shopify-import-maps GitHub}
  */
-const vitePluginShopifyImportMaps = (userOptions?: PluginOptions): Plugin[] => {
+const vitePluginShopifyImportMaps = (userOptions?: Partial<PluginOptions>): Plugin[] => {
   const {
     snippetFile = 'importmap.liquid',
     themeRoot = './',

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,18 +13,20 @@ const vitePluginShopifyImportMaps = (userOptions?: PluginOptions): Plugin[] => {
   const {
     snippetFile = 'importmap.liquid',
     themeRoot = './',
+    modulePreload = false,
     bareModules: bareModulesOption = false
   } = userOptions ?? {}
 
   const plugins = [
     preloadHelper(),
-    importMaps({ snippetFile, themeRoot, bareModules: bareModulesOption })
+    importMaps({ snippetFile, themeRoot, modulePreload, bareModules: bareModulesOption })
   ]
 
   if (bareModulesOption !== false) {
     plugins.push(bareModules({
       snippetFile,
       themeRoot,
+      modulePreload,
       bareModules: { ...{ defaultGroup: 'main', groups: {} }, ...(bareModulesOption as BareModules) }
     }))
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,4 +7,5 @@ export interface PluginOptions {
   snippetFile: string
   themeRoot: string
   bareModules: boolean | BareModules
+  modulePreload: boolean
 }


### PR DESCRIPTION
This option is supposed to generate `modulepreload` link tags for all modules in the import map. This can be useful when for example you use deferred module loading or dynamic imports. Unlike how vite only adds them for static imports.