### PR TITLE
fix: update lexer for template dynamic imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@stylistic/eslint-plugin": "^5.10.0",
     "@types/node": "^25.6.0",
     "bumpp": "^11.0.1",
-    "es-module-lexer": "^2.0.0",
+    "es-module-lexer": "^2.2.0",
     "eslint": "^10.2.1",
     "eslint-config-flat-gitignore": "^2.3.0",
     "eslint-config-love": "^153.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^11.0.1
         version: 11.0.1
       es-module-lexer:
-        specifier: ^2.0.0
-        version: 2.0.0
+        specifier: ^2.2.0
+        version: 2.2.0
       eslint:
         specifier: ^10.2.1
         version: 10.2.1(jiti@2.6.1)
@@ -1328,6 +1328,9 @@ packages:
 
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
+  es-module-lexer@2.2.0:
+    resolution: {integrity: sha512-3lGxdTXCLfe1MYfTz1y2ksAAUM4NAOP6rPEjxGJVKO7TZ5+tvHCaQWGpC4Y3IXvW3ece0Cz1cIP4FWBxOnGCTQ==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -4434,6 +4437,8 @@ snapshots:
   es-errors@1.3.0: {}
 
   es-module-lexer@2.0.0: {}
+
+  es-module-lexer@2.2.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,9 @@ allowBuilds:
   esbuild: true
   protobufjs: true
 
+minimumReleaseAgeExclude:
+  - es-module-lexer@2.2.0
+
 overrides:
   esbuild@<=0.24.2: '>=0.25.0'
   brace-expansion@>=1.0.0 <=1.1.11: '>=1.1.12'

--- a/tests/bare-modules.test.ts
+++ b/tests/bare-modules.test.ts
@@ -33,7 +33,7 @@ function plainViteConfig(
   return {
     plugins,
     build: {
-      minify: options.minify,
+      minify: options.minify ?? false,
       rollupOptions: {
         input: 'src/entry.ts',
       },

--- a/tests/bare-modules.test.ts
+++ b/tests/bare-modules.test.ts
@@ -1,6 +1,7 @@
 import type { InlineConfig } from 'vite'
 import { describe, expect, test } from 'vitest'
 import vitePluginShopifyImportMaps from '../src'
+import bareModulesPlugin from '../src/bare-modules'
 import type { BareModules } from '../src/types'
 import { buildFixture } from './helpers/build-fixture'
 
@@ -13,10 +14,26 @@ interface BareModulesCase {
   unexpectedAssets?: Array<{ file: string, contains: string[] }>
 }
 
-function plainViteConfig(plugins: ReturnType<typeof vitePluginShopifyImportMaps>): InlineConfig {
+interface TestChunk {
+  type: 'chunk'
+  fileName: string
+  name: string
+  code: string
+  moduleIds: string[]
+  map?: unknown
+}
+
+type RenderChunkHook = (code: string, chunk: TestChunk) => void
+type GenerateBundleHook = (options: { sourcemap: false }, bundle: Record<string, TestChunk>) => void
+
+function plainViteConfig(
+  plugins: ReturnType<typeof vitePluginShopifyImportMaps>,
+  options: { minify?: boolean } = {},
+): InlineConfig {
   return {
     plugins,
     build: {
+      minify: options.minify,
       rollupOptions: {
         input: 'src/entry.ts',
       },
@@ -107,4 +124,63 @@ describe('bare modules', () => {
       await fixture.cleanup()
     }
   })
+
+  test('rewrites no-substitution template-literal dynamic imports', () => {
+    const plugin = bareModulesPlugin({
+      bareModules: { defaultGroup: 'chunks', groups: {} },
+      modulePreload: false,
+      snippetFile: 'importmap.liquid',
+      themeRoot: '.',
+    })
+    const renderChunk = plugin.renderChunk as unknown as RenderChunkHook
+    const generateBundle = plugin.generateBundle as unknown as GenerateBundleHook
+    const bundle = {
+      'entry.js': createTestChunk('entry', 'export const load = () => import(`./feature.js`)'),
+      'feature.js': createTestChunk('feature', 'export const feature = true'),
+    }
+
+    for (const chunk of Object.values(bundle)) renderChunk(chunk.code, chunk)
+    generateBundle({ sourcemap: false }, bundle)
+
+    expect(bundle['entry.js'].code).toContain('import(`chunks/feature`)')
+    expect(bundle['entry.js'].code).not.toContain('./feature.js')
+  })
+
+  test('rewrites bare module imports in minified builds', async () => {
+    const fixture = await buildFixture('plain-vite', ({ themeRoot }) => plainViteConfig(
+      vitePluginShopifyImportMaps({
+        bareModules: { defaultGroup: 'chunks', groups: {} },
+        modulePreload: false,
+        themeRoot,
+      }),
+      { minify: true },
+    ))
+
+    try {
+      const importMap = await fixture.readSnippet()
+      const entry = await fixture.readAsset('entry.js')
+      const main = await fixture.readAsset('main.js')
+
+      expect(importMap).toContain('"chunks/entry"')
+      expect(importMap).toContain('"chunks/main"')
+      expect(importMap).toContain('"chunks/feature"')
+      expect(entry).toContain('import(`chunks/main`)')
+      expect(main).toContain('import(`chunks/feature`)')
+      expect(entry).not.toContain('./main.js')
+      expect(main).not.toContain('./feature.js')
+    }
+    finally {
+      await fixture.cleanup()
+    }
+  })
 })
+
+function createTestChunk(name: string, code: string): TestChunk {
+  return {
+    code,
+    fileName: `${name}.js`,
+    moduleIds: [`/fixture/src/${name}.ts`],
+    name,
+    type: 'chunk',
+  }
+}


### PR DESCRIPTION
Bump es-module-lexer to 2.2.0 so bare module rewriting handles minified template-literal dynamic imports. Add regression coverage for no-substitution template imports and minified builds.

Resolves #22
